### PR TITLE
fix: cli's verison bug

### DIFF
--- a/src/ragx/cli.py
+++ b/src/ragx/cli.py
@@ -47,7 +47,7 @@ def main():
 
     # Other commands
     subparsers.add_parser('webui', help='Run the web UI')
-    subparsers.add_parser('ver', help='Show version')
+    subparsers.add_parser('version', help='Show version')
     subparsers.add_parser('help', help='Show help')
 
     # Parse the arguments


### PR DESCRIPTION
if use`subparsers.add_parser('ver', help='Show version')`, the cli will pop up errors like no command found.