### PR TITLE
refactor: move prompts from config to separate files

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -44,5 +44,5 @@ query_transform = "none"
 metrics = ["NLG_chrf", "NLG_meteor", "NLG_wer", "NLG_cer", "NLG_chrf_pp","NLG_perplexity", "NLG_rouge_rouge1", "NLG_rouge_rouge2", "NLG_rouge_rougeL", "NLG_rouge_rougeLsum"]
 
 [prompt]
-text_qa_template_str = "Context information is below.\n---------------------\n{context_str}\n---------------------\nGiven the context information and not prior knowledge, answer the question: {query_str}\n"
-refine_template_str = "We have the opportunity to refine the original answer(only if needed) with some more context below.\n------------\n{context_msg}\n------------\nGiven the new context, refine the original answer to better answer the question: {query_str}. If the context isn't useful, output the original answer again.\nOriginal Answer: {existing_answer}"
+text_qa_template_path = "src/xrag/prompts/text_qa_template.txt"
+refine_template_path = "src/xrag/prompts/refine_template.txt"

--- a/src/xrag/config.py
+++ b/src/xrag/config.py
@@ -59,8 +59,8 @@ def create_default_config(config_file_path):
                           "NLG_rouge_rougeL", "NLG_rouge_rougeLsum"]
             },
             "prompt": {
-                "text_qa_template_str": "Context information is below.\n---------------------\n{context_str}\n---------------------\nGiven the context information and not prior knowledge, answer the question: {query_str}\n",
-                "refine_template_str": "We have the opportunity to refine the original answer(only if needed) with some more context below.\n------------\n{context_msg}\n------------\nGiven the new context, refine the original answer to better answer the question: {query_str}. If the context isn't useful, output the original answer again.\nOriginal Answer: {existing_answer}"
+                "text_qa_template_path": "src/xrag/prompts/text_qa_template.txt",
+                "refine_template_path": "src/xrag/prompts/refine_template.txt"
             }
         }
         with open(config_file_path, 'w', encoding='utf-8') as f:
@@ -88,6 +88,37 @@ class Config:
                     setattr(cls._instance, key, value)
 
         return cls._instance
+
+    def _load_prompt_template(self, file_path: str):
+        """Load prompt template from file."""
+        try:
+            # Handle relative paths from the project root
+            if not os.path.isabs(file_path):
+                project_root = os.path.dirname(os.path.abspath("config.toml"))
+                file_path = os.path.join(project_root, file_path)
+
+            with open(file_path, "r", encoding="utf-8") as f:
+                return f.read().strip()
+        except FileNotFoundError:
+            logger.error(f"Prompt template file not found: {file_path}")
+            return ""
+        except Exception as e:
+            logger.error(f"Error loading prompt template from {file_path}: {e}")
+            return ""
+
+    @property
+    def text_qa_template_str(self):
+        """Get the text QA template string from file."""
+        if hasattr(self, "text_qa_template_path"):
+            return self._load_prompt_template(self.text_qa_template_path)
+        return ""
+
+    @property
+    def refine_template_str(self):
+        """Get the refine template string from file."""
+        if hasattr(self, "refine_template_path"):
+            return self._load_prompt_template(self.refine_template_path)
+        return ""
 
     def update_config(self, overrides):
         for key, value in overrides.items():

--- a/src/xrag/default_config.toml
+++ b/src/xrag/default_config.toml
@@ -44,5 +44,5 @@ query_transform = "none"
 metrics = ["NLG_chrf", "NLG_meteor", "NLG_wer", "NLG_cer", "NLG_chrf_pp","NLG_perplexity", "NLG_rouge_rouge1", "NLG_rouge_rouge2", "NLG_rouge_rougeL", "NLG_rouge_rougeLsum"]
 
 [prompt]
-text_qa_template_str = "Context information is below.\n---------------------\n{context_str}\n---------------------\nGiven the context information and not prior knowledge, answer the question: {query_str}\n"
-refine_template_str = "We have the opportunity to refine the original answer(only if needed) with some more context below.\n------------\n{context_msg}\n------------\nGiven the new context, refine the original answer to better answer the question: {query_str}. If the context isn't useful, output the original answer again.\nOriginal Answer: {existing_answer}"
+text_qa_template_path = "src/xrag/prompts/text_qa_template.txt"
+refine_template_path = "src/xrag/prompts/refine_template.txt"

--- a/src/xrag/prompts/refine_template.txt
+++ b/src/xrag/prompts/refine_template.txt
@@ -1,0 +1,6 @@
+We have the opportunity to refine the original answer (only if needed) with some more context below.
+------------
+{context_msg}
+------------
+Given the new context, refine the original answer to better answer the question: {query_str}. If the context isn't useful, output the original answer again.
+Original Answer: {existing_answer}

--- a/src/xrag/prompts/text_qa_template.txt
+++ b/src/xrag/prompts/text_qa_template.txt
@@ -1,0 +1,5 @@
+Context information is below.
+---------------------
+{context_str}
+---------------------
+Given the context information and not prior knowledge, answer the question: {query_str}


### PR DESCRIPTION
Moved prompt content from config file fields to dedicated prompt files in a separate directory (`src/xrag/prompts`).
Updated config file to store file paths instead of inline prompt content. 

This allows improved maintainability, enhanced readability and scalability.