### PR TITLE
Fix invalid TOML value in `config.toml`

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -98,7 +98,7 @@ retriver_type_CUSTOM='bm25_and' # bm25_and,keyword_or
 retriver_type_QUERYFUSION='normal' # normal,reciprocal_rank
 num_quries_QUERYFUSION=4
 similarity_top_k_QUERYFUSION=2
-retriever_weight_QUERYFUSION=null  # default: [1 / len(index)] * len(index)
+retriever_weight_QUERYFUSION=[]  # default: [1 / len(index)] * len(index)
 
 # 8.AutoMerging
 similarity_top_k_AUTOMERGING=6

--- a/src/xrag/retrievers/retriever.py
+++ b/src/xrag/retrievers/retriever.py
@@ -180,7 +180,7 @@ def query_fusion_retriever(index, num_queries=4, similarity_top_k=2, retriver_ty
     query_fusion_r = None
     if not isinstance(index, list):
         index = [index]
-    if retriever_weight is None:
+    if not retriever_weight:
         retriever_weight = [1 / len(index)] * len(index)
     
     if retriver_type_QUERYFUSION.lower()=='normal':


### PR DESCRIPTION
Fixes an invalid TOML value in the `config.toml` file. 

The line:
```toml
retriever_weight_QUERYFUSION=null  # default: [1 / len(index)] * len(index)
```
uses null, which is not a valid TOML value and causes a `ValueError: Invalid date or number`.

To resolve this, the value should be set to 0, [], or removed entirely if optional.